### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/Formula/act.rb
+++ b/Formula/act.rb
@@ -6,7 +6,6 @@ class Act < Formula
   desc "Run GitHub Actions locally"
   homepage "https://github.com/nektos/act"
   version "0.2.24"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
It is deprecated.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the nektos/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/nektos/homebrew-tap/Formula/act.rb:9
```